### PR TITLE
[FIX] Bypass constrains if sequence is defined

### DIFF
--- a/account_sequence_option/models/account_move.py
+++ b/account_sequence_option/models/account_move.py
@@ -37,6 +37,13 @@ class AccountMove(models.Model):
             if sequence:
                 rec.name = "/"
 
+    # Bypass constrains if sequence is defined
+    def _constrains_date_sequence(self):
+        for record in self:
+            sequence = self.env["sequence.option"].get_sequence(record)
+            if not sequence:
+                record.super()._constrains_date_sequence()
+
     def _get_last_sequence_domain(self, relaxed=False):
         (where_string, param) = super()._get_last_sequence_domain(relaxed=relaxed)
         where_string += " AND coalesce(sequence_option, false) = false "


### PR DESCRIPTION
When trying to use this module, I realized that when sequence is defined, the constrain on date/name will not validate.
I have added a check to bypass constrains if sequence is defined